### PR TITLE
Fix trustedApps regexp.

### DIFF
--- a/pryv.io/cluster/core/core/conf/core.json
+++ b/pryv.io/cluster/core/core/conf/core.json
@@ -18,7 +18,7 @@
   },
   "auth": {
     "adminAccessKey": "CORE_SYSTEM_KEY",
-    "trustedApps": "*@https://*.DOMAIN, *@http://pryv.github.io, *@https://*.rec.la",
+    "trustedApps": "*@https://*.DOMAIN*, *@http://pryv.github.io*, *@https://*.rec.la*",
     "sessionMaxAge": 1209600000,
     "ssoCookieDomain": ".DOMAIN",
     "ssoCookieSignSecret": "OVERRIDE_ME",

--- a/pryv.io/single node/pryv/core/conf/core.json
+++ b/pryv.io/single node/pryv/core/conf/core.json
@@ -18,7 +18,7 @@
   },
   "auth": {
     "adminAccessKey": "CORE_ADMIN_KEY",
-    "trustedApps": "*@https://*.DOMAIN, *@http://pryv.github.io, *@https://*.rec.la",
+    "trustedApps": "*@https://*.DOMAIN*, *@http://pryv.github.io*, *@https://*.rec.la*",
     "sessionMaxAge": 1209600000,
     "ssoCookieDomain": ".DOMAIN",
     "ssoCookieSignSecret": "OVERRIDE_ME",


### PR DESCRIPTION
When configuring the e-motiph platform using the config-template, I discovered that the "Trusted apps only" calls were not working as expected (login from app-web).

Then I looked at config-pryv.me and config-pryv.li and saw that the trustedApps records have aditionnal * at the end:

**Template**:
`"trustedApps": "*@https://*.DOMAIN, *@http://pryv.github.io, *@https://*.rec.la"`

**pryv.me/li**:
`"trustedApps": "*@https://*.rec.la*, *@https://*.pryv.li*, *@https://pryv.github.io*"`