### PR TITLE
refactor request logs

### DIFF
--- a/pryv.io/cluster/config-leader/data/core/nginx/conf/nginx.conf
+++ b/pryv.io/cluster/config-leader/data/core/nginx/conf/nginx.conf
@@ -13,7 +13,17 @@ events {
 }
 
 http {
-    access_log    /app/log/nginx.access.log;
+    log_format default  '[$time_local] $remote_addr "$host" '
+                        '"$request" $status $body_bytes_sent '
+                        '$request_time';
+    access_log      /app/log/nginx.access.log default;
+
+    # uncomment this to log request body
+    #log_format debug escape=none    '[$time_local] $remote_addr "$host" '
+    #                                '"$request" $status $body_bytes_sent '
+    #                                '$request_time '
+    #                                '"$request_body"';
+    #access_log      /app/log/nginx.debug.log debug;
 
     types_hash_max_size 2048;
 

--- a/pryv.io/cluster/config-leader/data/core/nginx/conf/site-443.conf
+++ b/pryv.io/cluster/config-leader/data/core/nginx/conf/site-443.conf
@@ -42,7 +42,6 @@ upstream follower_server {
 server {
   listen                443 ssl;
   server_name           *.DOMAIN;
-  access_log            /app/log/api.access.log;
 
   client_max_body_size  20M;
   

--- a/pryv.io/cluster/config-leader/data/reg-master/nginx/conf/nginx.conf
+++ b/pryv.io/cluster/config-leader/data/reg-master/nginx/conf/nginx.conf
@@ -12,7 +12,17 @@ events {
 }
 
 http {
-    access_log    /app/log/nginx.access.log;
+    log_format default  '[$time_local] $remote_addr "$host" '
+                        '"$request" $status $body_bytes_sent '
+                        '$request_time';
+    access_log      /app/log/nginx.access.log default;
+
+    # uncomment this to log request body
+    #log_format debug escape=none    '[$time_local] $remote_addr "$host" '
+    #                                '"$request" $status $body_bytes_sent '
+    #                                '$request_time '
+    #                                '"$request_body"';
+    #access_log      /app/log/nginx.debug.log debug;
 
     types_hash_max_size 2048;
 

--- a/pryv.io/cluster/config-leader/data/reg-master/nginx/conf/site.conf
+++ b/pryv.io/cluster/config-leader/data/reg-master/nginx/conf/site.conf
@@ -19,7 +19,6 @@ upstream admin_panel_server {
 server {
   listen               443 ssl;
   server_name          lead.DOMAIN;
-  access_log           /app/log/lead.log;
 
   client_max_body_size  5M;
 
@@ -42,7 +41,6 @@ server {
 server {
   listen               443 ssl;
   server_name          adm.DOMAIN;
-  access_log           /app/log/admin-panel.log;
 
   client_max_body_size  5M;
 
@@ -64,7 +62,6 @@ server {
 server {
   listen               443 ssl;
   server_name          mail.DOMAIN;
-  access_log           /app/log/mail.log;
 
   client_max_body_size  5M;
 
@@ -87,7 +84,6 @@ server {
 server {
   listen               443 ssl;
   server_name          *.DOMAIN;
-  access_log           /app/log/reg.access.log;
 
   client_max_body_size  5M;
 

--- a/pryv.io/cluster/config-leader/data/reg-slave/nginx/conf/nginx.conf
+++ b/pryv.io/cluster/config-leader/data/reg-slave/nginx/conf/nginx.conf
@@ -12,7 +12,17 @@ events {
 }
 
 http {
-    access_log    /app/log/nginx.access.log;
+    log_format default  '[$time_local] $remote_addr "$host" '
+                        '"$request" $status $body_bytes_sent '
+                        '$request_time';
+    access_log      /app/log/nginx.access.log default;
+
+    # uncomment this to log request body
+    #log_format debug escape=none    '[$time_local] $remote_addr "$host" '
+    #                                '"$request" $status $body_bytes_sent '
+    #                                '$request_time '
+    #                                '"$request_body"';
+    #access_log      /app/log/nginx.debug.log debug;
 
     types_hash_max_size 2048;
 

--- a/pryv.io/cluster/config-leader/data/reg-slave/nginx/conf/site.conf
+++ b/pryv.io/cluster/config-leader/data/reg-slave/nginx/conf/site.conf
@@ -6,7 +6,6 @@ upstream follower_server {
 server {
   listen               443 ssl;
   server_name          *.DOMAIN;
-  access_log           /app/log/reg.access.log;
 
   client_max_body_size  5M;
 

--- a/pryv.io/cluster/config-leader/data/static/nginx/conf/nginx.conf
+++ b/pryv.io/cluster/config-leader/data/static/nginx/conf/nginx.conf
@@ -10,7 +10,17 @@ events {
 }
 
 http {
-    access_log    /app/log/nginx.access.log;
+    log_format default  '[$time_local] $remote_addr "$host" '
+                        '"$request" $status $body_bytes_sent '
+                        '$request_time';
+    access_log      /app/log/nginx.access.log default;
+
+    # uncomment this to log request body
+    #log_format debug escape=none    '[$time_local] $remote_addr "$host" '
+    #                                '"$request" $status $body_bytes_sent '
+    #                                '$request_time '
+    #                                '"$request_body"';
+    #access_log      /app/log/nginx.debug.log debug;
 
     types_hash_max_size 2048;
 

--- a/pryv.io/cluster/config-leader/data/static/nginx/conf/site-443-mfa.conf
+++ b/pryv.io/cluster/config-leader/data/static/nginx/conf/site-443-mfa.conf
@@ -1,7 +1,6 @@
 server {
   listen                443 ssl;
   server_name           mfa.DOMAIN;
-  access_log            /app/log/mfa.access.log;
 
   client_max_body_size  5M;
 

--- a/pryv.io/cluster/config-leader/data/static/nginx/conf/site-443.conf
+++ b/pryv.io/cluster/config-leader/data/static/nginx/conf/site-443.conf
@@ -9,7 +9,6 @@ upstream app_web_auth3_server {
 server {
   listen               443 ssl;
   server_name          sw.DOMAIN;
-  access_log           /app/log/sw.access.log;
 
   client_max_body_size 5M;
 

--- a/pryv.io/single-node/config-leader/data/singlenode/nginx/conf/nginx.conf
+++ b/pryv.io/single-node/config-leader/data/singlenode/nginx/conf/nginx.conf
@@ -10,7 +10,17 @@ events {
 }
 
 http {
-    access_log    /app/log/nginx.access.log;
+    log_format default  '[$time_local] $remote_addr "$host" '
+                        '"$request" $status $body_bytes_sent '
+                        '$request_time';
+    access_log      /app/log/nginx.access.log default;
+
+    # uncomment this to log request body
+    #log_format debug escape=none    '[$time_local] $remote_addr "$host" '
+    #                                '"$request" $status $body_bytes_sent '
+    #                                '$request_time '
+    #                                '"$request_body"';
+    #access_log      /app/log/nginx.debug.log debug;
 
     types_hash_max_size 2048;
 

--- a/pryv.io/single-node/config-leader/data/singlenode/nginx/conf/site-443-mfa.conf
+++ b/pryv.io/single-node/config-leader/data/singlenode/nginx/conf/site-443-mfa.conf
@@ -1,7 +1,6 @@
 server {
   listen                443 ssl;
   server_name           mfa.DOMAIN;
-  access_log            /app/log/mfa.access.log;
 
   client_max_body_size  5M;
 

--- a/pryv.io/single-node/config-leader/data/singlenode/nginx/conf/site-443.conf
+++ b/pryv.io/single-node/config-leader/data/singlenode/nginx/conf/site-443.conf
@@ -54,7 +54,6 @@ upstream app_web_auth3_server {
 server {
   listen               443 ssl;
   server_name          lead.DOMAIN;
-  access_log           /app/log/lead.log;
 
   client_max_body_size  5M;
 
@@ -77,7 +76,6 @@ server {
 server {
   listen               443 ssl;
   server_name          adm.DOMAIN;
-  access_log           /app/log/admin-panel.log;
 
   client_max_body_size  5M;
 
@@ -99,7 +97,6 @@ server {
 server {
   listen               443 ssl;
   server_name          reg.DOMAIN access.DOMAIN;
-  access_log           /app/log/reg.access.log;
 
   client_max_body_size 5M;
 
@@ -122,7 +119,6 @@ server {
 server {
   listen               443 ssl;
   server_name          *.DOMAIN;
-  access_log           /app/log/api.access.log;
 
   client_max_body_size 20M;
 
@@ -202,7 +198,6 @@ server {
 server {
   listen               443 ssl;
   server_name          sw.DOMAIN;
-  access_log           /app/log/sw.access.log;
 
   client_max_body_size 5M;
 


### PR DESCRIPTION
add request time, remove remote_user (prints basic auth token), referer & user agent. Centralize logs in single file (instead of per service)